### PR TITLE
I modified the tags to increase its readability

### DIFF
--- a/content/StorageScanner.ts
+++ b/content/StorageScanner.ts
@@ -69,8 +69,8 @@ export = new class StorageScanner {
 
       let save = false
 
-      if (this.updateTag(item, '#broken', !(await item.getFilePathAsync()))) save = true
-      if (this.updateTag(item, '#duplicates', attachment.duplicates > 1)) save = true
+      if (this.updateTag(item, '#broken_attachments ', !(await item.getFilePathAsync()))) save = true
+      if (this.updateTag(item, '#duplicate_attachments', attachment.duplicates > 1)) save = true
       Zotero.debug(`StorageScanner.save: ${save}`)
 
       if (save) await item.saveTx()


### PR DESCRIPTION
For green-hands, they may don't know the difference between the tag and the folder. Also the tag may be ignored as some of them (e.g. my colleges) don't use the tag system. Thus I'd like to make them to clearly understand how could they modify the broken&duplicate attachments through indicative tags.：-）