### PR TITLE
Use tag name #multiple_attachments_of_same_type

### DIFF
--- a/content/zotero-storage-scanner.ts
+++ b/content/zotero-storage-scanner.ts
@@ -100,7 +100,7 @@ class StorageScanner {
       let save = false
 
       if (this.updateTag(item, '#broken_attachments', !attachment.isLinkedURL && !(await item.getFilePathAsync()))) save = true
-      if (this.updateTag(item, '#duplicate_attachments', attachment.duplicates > 1)) save = true
+      if (this.updateTag(item, '#multiple_attachments_of_same_type', attachment.duplicates > 1)) save = true
       Zotero.debug(`StorageScanner.save: ${save}`)
 
       if (save) await item.saveTx()


### PR DESCRIPTION
instead of #duplicate_attachments, as in #12

This is a hint that there might be duplicates, but no guarantee they are identical files, or even the same version of the document.